### PR TITLE
remove use of `#columns_hash` that breaks in multiple-database use

### DIFF
--- a/lib/audit_tables/base.rb
+++ b/lib/audit_tables/base.rb
@@ -54,8 +54,6 @@ module AuditTables
         t.string :audit_operation, null: false
         t.datetime :audit_timestamp, null: false
       end
-
-      add_column audit_table_name, :id, klass.columns_hash['id'].type
     end
 
     def default

--- a/spec/audit_table_spec.rb
+++ b/spec/audit_table_spec.rb
@@ -41,6 +41,10 @@ describe AuditTables do
         AuditTables.create_audit_table_for(:entities)
 
         expect(ActiveRecord::Base.connection.data_source_exists?(:audit_entities)).to eq(true)
+        ActiveRecord::Base.connection.columns(:entities).each do |source_col|
+          audit_col = ActiveRecord::Base.connection.columns(:audit_entities).select {|c| c.name == source_col.name}.first
+          expect(audit_col.type).to eq(source_col.type)
+        end
       end
     end
 


### PR DESCRIPTION
also add assertions to test showing audit table includes columns matching source columns